### PR TITLE
Change article access method to ID rather than title

### DIFF
--- a/backend/src/api/articles.py
+++ b/backend/src/api/articles.py
@@ -123,7 +123,9 @@ def get_article(article_id: int):
     with Database() as db:
         try:
             # this will fail if the article id does not exist
-            title, description, date_published, refs = get_article_metadata(db, article_id)
+            title, description, date_published, refs = get_article_metadata(
+                db, article_id
+            )
         except Exception as e:
             raise HTTPException(404, detail=str(e))
 

--- a/frontend/src/Router.svelte
+++ b/frontend/src/Router.svelte
@@ -47,13 +47,13 @@
 		<!-- all things articles -->
 		<Route path="/articles"><Articles /></Route>
 		<Route path="/article/:id" let:params
-			><Article articleTitle={params.id} /></Route
+			><Article articleID={params.id} /></Route
 		>
 		<Route path="/article/edit/:id" let:params
-			><Article articleTitle={params.id} editMode />
+			><Article articleID={params.id} editMode />
 		</Route>
 		<Route path="/article/meta/edit/:id" let:params
-			><EditArticle articleTitle={params.id} />
+			><EditArticle articleID={params.id} />
 		</Route>
 		<Route path="/upload/article"><UploadArticle /></Route>
 

--- a/frontend/src/lib/openapi/services/DefaultService.ts
+++ b/frontend/src/lib/openapi/services/DefaultService.ts
@@ -51,6 +51,25 @@ export class DefaultService {
         });
     }
     /**
+     * Admin Signup
+     * @param requestBody
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static adminSignup(
+        requestBody: LoginBody,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/users/admin/signup',
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
      * Search Proteins
      * @param requestBody
      * @returns SearchProteinsResults Successful Response
@@ -369,26 +388,26 @@ export class DefaultService {
      * get_article
      *
      * Args:
-     * title (str): title of the article
+     * id (int): ID of the article
      *
      * Raises:
-     * HTTPException: status 404 if the article is not found by the given title
+     * HTTPException: status 404 if the article is not found by the given ID
      * HTTPException: status 500 if any other errors occur
      *
      * Returns:
      * Article
-     * @param title
+     * @param articleId
      * @returns Article Successful Response
      * @throws ApiError
      */
     public static getArticle(
-        title: string,
+        articleId: number,
     ): CancelablePromise<Article> {
         return __request(OpenAPI, {
             method: 'GET',
-            url: '/article/meta/{title}',
+            url: '/article/meta/{article_id}',
             path: {
-                'title': title,
+                'article_id': articleId,
             },
             errors: {
                 422: `Validation Error`,
@@ -397,18 +416,18 @@ export class DefaultService {
     }
     /**
      * Delete Article
-     * @param title
+     * @param articleId
      * @returns any Successful Response
      * @throws ApiError
      */
     public static deleteArticle(
-        title: string,
+        articleId: number,
     ): CancelablePromise<any> {
         return __request(OpenAPI, {
             method: 'DELETE',
-            url: '/article/meta/{title}',
+            url: '/article/meta/{article_id}',
             path: {
-                'title': title,
+                'article_id': articleId,
             },
             errors: {
                 422: `Validation Error`,

--- a/frontend/src/routes/Article.svelte
+++ b/frontend/src/routes/Article.svelte
@@ -21,7 +21,7 @@
 	import References from "../lib/References.svelte";
 	import Markdown from "../lib/Markdown.svelte";
 
-	export let articleTitle: string;
+	export let articleID: number;
 	export let editMode = false;
 
 	const textWidth = "800px";
@@ -40,7 +40,7 @@
 
 	async function refreshArticle() {
 		try {
-			article = await Backend.getArticle(articleTitle);
+			article = await Backend.getArticle(articleID);
 		} catch (e) {
 			console.error(e);
 			notFound = true;
@@ -60,7 +60,7 @@
 								outline
 								size="xs"
 								on:click={async () => {
-									navigate(`/article/${articleTitle}`);
+									navigate(`/article/${articleID}`);
 								}}
 								><ArrowLeftOutline class="mr-1" size="sm" />Back
 								to viewing
@@ -75,7 +75,7 @@
 								outline
 								size="xs"
 								on:click={async () => {
-									navigate(`/article/edit/${articleTitle}`);
+									navigate(`/article/edit/${articleID}`);
 								}}
 								><EditOutline class="mr-1" size="sm" />Edit
 								Article
@@ -87,7 +87,7 @@
 								size="xs"
 								on:click={async () => {
 									navigate(
-										`/article/meta/edit/${articleTitle}`
+										`/article/meta/edit/${articleID}`
 									);
 								}}
 								><EditOutline class="mr-1" size="sm" />Edit
@@ -197,7 +197,7 @@
 										size="xs"
 										on:click={async () => {
 											navigate(
-												`/article/meta/edit/${articleTitle}`
+												`/article/meta/edit/${articleID}`
 											);
 										}}
 										><EditOutline
@@ -214,7 +214,7 @@
 			</div>
 		</div>
 	{:else if notFound}
-		{articleTitle} not found
+		{articleID} not found
 	{/if}
 </section>
 

--- a/frontend/src/routes/Articles.svelte
+++ b/frontend/src/routes/Articles.svelte
@@ -23,7 +23,7 @@
 			<div
 				class="article"
 				on:click={() => {
-					navigate(`/article/${a.title}`);
+					navigate(`/article/${a.id}`);
 				}}
 			>
 				{#if a.datePublished}

--- a/frontend/src/routes/EditArticle.svelte
+++ b/frontend/src/routes/EditArticle.svelte
@@ -4,7 +4,7 @@
 	import { Backend, setToken, type Article } from "../lib/backend";
 	import { onMount } from "svelte";
     import { user } from "../lib/stores/user";
-	export let articleTitle: string;
+	export let articleID: number;
 
 	let title: string = "";
 	let description: string = "";
@@ -22,7 +22,7 @@
 		}
         
 		try {
-			article = await Backend.getArticle(articleTitle);
+			article = await Backend.getArticle(articleID);
 		} catch (e) {
 			console.error(e);
 			articlesExists = false;
@@ -136,7 +136,7 @@
 				on:click={async () => {
 					try {
 						setToken();
-						await Backend.deleteArticle(article.title);
+						await Backend.deleteArticle(article.id);
 						navigate(`/articles`);
 					} catch (e) {
 						console.error(e);
@@ -145,7 +145,7 @@
 			>
 		</div>
 	{:else}
-		Article with the title '{articleTitle}' does not exist. So cannot be
+		Article with the title '{articleID}' does not exist. So cannot be
 		edited.
 	{/if}
 </section>


### PR DESCRIPTION
This change solves issues with certain characters in article titles breaking URLs, and in general should be safer as it allows for fewer inconsistencies with URLs.

Solves #267 

