### PR TITLE
Add table for editing user information, fix admin-only pages, and correctly store user info in cookies for later use.

### DIFF
--- a/backend/src/api/users.py
+++ b/backend/src/api/users.py
@@ -1,7 +1,15 @@
 from fastapi import APIRouter
 import logging as log
 from passlib.hash import bcrypt
-from ..api_types import SignupBody, SignupResponse, LoginBody, LoginResponse
+from ..api_types import (
+    SignupBody,
+    SignupResponse,
+    LoginBody,
+    LoginResponse,
+    UsersResponse,
+    UserResponse,
+)
+
 from ..db import Database
 from ..auth import generate_auth_token
 from fastapi.exceptions import HTTPException
@@ -70,3 +78,19 @@ def admin_signup(body: LoginBody):
             db.execute(query, [body.email, body.email, hashed_password, True])
         except Exception:
             raise HTTPException(501, "signup insert failed")
+
+
+@router.get("/users/", response_model=UsersResponse)
+def get_users():
+    with Database() as db:
+        query = """SELECT username, email, admin FROM users;"""
+        users_list = db.execute_return(query)
+        if users_list is not None:
+            return UsersResponse(
+                users=[
+                    UserResponse(username=user[0], email=user[1], admin=user[2])
+                    for user in users_list
+                ]
+            )
+        else:
+            return UsersResponse(users=[])

--- a/backend/src/api_types.py
+++ b/backend/src/api_types.py
@@ -99,6 +99,7 @@ class CompareResponse(CamelModel):
 
 
 class UserResponse(CamelModel):
+    id: int
     username: str
     email: str
     admin: bool
@@ -106,3 +107,15 @@ class UserResponse(CamelModel):
 
 class UsersResponse(CamelModel):
     users: list[UserResponse]
+
+
+class UserIDResponse(CamelModel):
+    id: int
+
+
+class UserBody(CamelModel):
+    id: int
+    username: str | None = None
+    email: str | None = None
+    admin: bool | None = None
+    password: str | None = None

--- a/backend/src/api_types.py
+++ b/backend/src/api_types.py
@@ -96,3 +96,13 @@ class CompareBody(CamelModel):
 
 class CompareResponse(CamelModel):
     file: list[str]
+
+
+class UserResponse(CamelModel):
+    username: str
+    email: str
+    admin: bool
+
+
+class UsersResponse(CamelModel):
+    users: list[UserResponse]

--- a/backend/src/api_types.py
+++ b/backend/src/api_types.py
@@ -86,6 +86,7 @@ class LoginBody(CamelModel):
 
 class LoginResponse(CamelModel):
     token: str
+    user_id: int
     error: str
 
 

--- a/frontend/src/Router.svelte
+++ b/frontend/src/Router.svelte
@@ -17,6 +17,7 @@
 	import EditArticle from "./routes/EditArticle.svelte";
 	import Upload from "./routes/Upload.svelte";
 	import FullScreen from "./routes/FullScreen.svelte";
+	import UserList from "./routes/UserList.svelte";
 </script>
 
 <Router>
@@ -29,6 +30,7 @@
 		<Route path="/proteins"><Proteins /></Route>
 		<Route path="/login"><Login /></Route>
 		<Route path="/signup"><Signup /></Route>
+		<Route path="/users"><UserList /></Route>
 		<Route path="/upload"><Upload /></Route>
 
 		<!-- all things proteins -->

--- a/frontend/src/lib/Header.svelte
+++ b/frontend/src/lib/Header.svelte
@@ -21,6 +21,15 @@
 		if (Cookies.get("auth")) {
 			$user.loggedIn = true;
 		}
+		
+		if (Cookies.get("admin")){
+			$user.admin = (Cookies.get("admin") === "true")
+		}
+
+		let user_id = Cookies.get("id")
+		if ( user_id != undefined){
+			$user.id = parseInt(user_id)
+		}
 	});
 </script>
 

--- a/frontend/src/lib/UserTable.svelte
+++ b/frontend/src/lib/UserTable.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+	import { Backend, clearToken, type UserResponse, type UserBody} from "../lib/backend";
+	import { onMount } from "svelte";
+	
+	let userList: UserResponse[] = [];
+	let unique = {};
+
+	export let reloadTable: () => void;
+	
+	onMount(async () => {
+		const response = await Backend.getUsers();
+		userList = response.users;
+
+	});
+
+
+	async function getID(username: string) {
+		return (await Backend.getUserId(username)).id;
+	}
+	
+	async function deleteUser(username: string) {
+		const id = await getID(username);
+		await Backend.deleteUser(id);
+		reloadTable()
+	}
+
+	async function editUsername(username: string) {
+		const id = await getID(username);
+		const newUsername = prompt("Enter new username", username);
+		const user: UserBody = {
+			id : id,
+			username: newUsername,
+		};
+		await Backend.editUser(id, user);
+		reloadTable()
+	}
+
+	async function editEmail(username: string, email: string) {
+		const id = await getID(username);
+		const newEmail = prompt("Enter new email", email);
+		const user: UserBody = {
+			id : id,
+			email: newEmail,
+		};
+		await Backend.editUser(id, user);
+		reloadTable()
+	}
+
+	async function editRole(username: string) {
+		const id = await getID(username);
+		const isAlreadyAdmin = (await Backend.getUser(id)).admin;
+		const newRole = isAlreadyAdmin ? false : true;
+		const user: UserBody = {
+			id : id,
+			admin: newRole,
+		};
+		await Backend.editUser(id, user);
+		reloadTable()
+	}
+</script>
+
+<tr>
+    <th>Username</th>
+    <th>Email</th>
+    <th>Admin</th>
+    <th>Proteins Submitted</th>
+</tr>
+{#each userList as user}
+    <tr>
+        <td>{user.username} <button on:click={editUsername(user.username)}>Edit Username</button></td>
+        <td>{user.email} <button on:click = {editEmail(user.username, user.email)}>Edit Email</button></td>
+        <td class="admin">{user.admin.toString()} <button on:click ={editRole(user.username)}>Toggle Admin</button></td>
+        <td></td>
+    </tr>
+{/each}
+
+
+<style>
+
+	th, td {
+		border: 1px solid black;
+		padding: 8px;
+		text-align: left;
+	}
+
+	.admin {
+		text-transform: capitalize;
+	}
+
+	th {
+		background-color: hsla(205, 57%, 23%, 0.35);
+	}
+	button {
+		background-color: hsla(205, 57%, 23%, 0.35);
+		border-radius: 15px;
+		padding: 5px;
+	}
+</style>

--- a/frontend/src/lib/openapi/index.ts
+++ b/frontend/src/lib/openapi/index.ts
@@ -38,6 +38,8 @@ export type { UploadArticleTextComponent } from './models/UploadArticleTextCompo
 export type { UploadBody } from './models/UploadBody';
 export { UploadError } from './models/UploadError';
 export type { UploadPNGBody } from './models/UploadPNGBody';
+export type { UserResponse } from './models/UserResponse';
+export type { UsersResponse } from './models/UsersResponse';
 export type { ValidationError } from './models/ValidationError';
 
 export { DefaultService } from './services/DefaultService';

--- a/frontend/src/lib/openapi/index.ts
+++ b/frontend/src/lib/openapi/index.ts
@@ -38,6 +38,8 @@ export type { UploadArticleTextComponent } from './models/UploadArticleTextCompo
 export type { UploadBody } from './models/UploadBody';
 export { UploadError } from './models/UploadError';
 export type { UploadPNGBody } from './models/UploadPNGBody';
+export type { UserBody } from './models/UserBody';
+export type { UserIDResponse } from './models/UserIDResponse';
 export type { UserResponse } from './models/UserResponse';
 export type { UsersResponse } from './models/UsersResponse';
 export type { ValidationError } from './models/ValidationError';

--- a/frontend/src/lib/openapi/models/LoginResponse.ts
+++ b/frontend/src/lib/openapi/models/LoginResponse.ts
@@ -4,6 +4,7 @@
 /* eslint-disable */
 export type LoginResponse = {
     token: string;
+    userId: number;
     error: string;
 };
 

--- a/frontend/src/lib/openapi/models/UserBody.ts
+++ b/frontend/src/lib/openapi/models/UserBody.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type UserBody = {
+    id: number;
+    username?: (string | null);
+    email?: (string | null);
+    admin?: (boolean | null);
+    password?: (string | null);
+};
+

--- a/frontend/src/lib/openapi/models/UserIDResponse.ts
+++ b/frontend/src/lib/openapi/models/UserIDResponse.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type UserIDResponse = {
+    id: number;
+};
+

--- a/frontend/src/lib/openapi/models/UserResponse.ts
+++ b/frontend/src/lib/openapi/models/UserResponse.ts
@@ -1,0 +1,10 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type UserResponse = {
+    username: string;
+    email: string;
+    admin: boolean;
+};
+

--- a/frontend/src/lib/openapi/models/UserResponse.ts
+++ b/frontend/src/lib/openapi/models/UserResponse.ts
@@ -3,6 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 export type UserResponse = {
+    id: number;
     username: string;
     email: string;
     admin: boolean;

--- a/frontend/src/lib/openapi/models/UsersResponse.ts
+++ b/frontend/src/lib/openapi/models/UsersResponse.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { UserResponse } from './UserResponse';
+export type UsersResponse = {
+    users: Array<UserResponse>;
+};
+

--- a/frontend/src/lib/openapi/services/DefaultService.ts
+++ b/frontend/src/lib/openapi/services/DefaultService.ts
@@ -29,6 +29,7 @@ import type { UploadArticleTextComponent } from '../models/UploadArticleTextComp
 import type { UploadBody } from '../models/UploadBody';
 import type { UploadError } from '../models/UploadError';
 import type { UploadPNGBody } from '../models/UploadPNGBody';
+import type { UsersResponse } from '../models/UsersResponse';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
 import { request as __request } from '../core/request';
@@ -88,6 +89,17 @@ export class DefaultService {
             errors: {
                 422: `Validation Error`,
             },
+        });
+    }
+    /**
+     * Get Users
+     * @returns UsersResponse Successful Response
+     * @throws ApiError
+     */
+    public static getUsers(): CancelablePromise<UsersResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/users/',
         });
     }
     /**

--- a/frontend/src/lib/openapi/services/DefaultService.ts
+++ b/frontend/src/lib/openapi/services/DefaultService.ts
@@ -29,6 +29,9 @@ import type { UploadArticleTextComponent } from '../models/UploadArticleTextComp
 import type { UploadBody } from '../models/UploadBody';
 import type { UploadError } from '../models/UploadError';
 import type { UploadPNGBody } from '../models/UploadPNGBody';
+import type { UserBody } from '../models/UserBody';
+import type { UserIDResponse } from '../models/UserIDResponse';
+import type { UserResponse } from '../models/UserResponse';
 import type { UsersResponse } from '../models/UsersResponse';
 import type { CancelablePromise } from '../core/CancelablePromise';
 import { OpenAPI } from '../core/OpenAPI';
@@ -100,6 +103,90 @@ export class DefaultService {
         return __request(OpenAPI, {
             method: 'GET',
             url: '/users/',
+        });
+    }
+    /**
+     * Get User Id
+     * @param username
+     * @returns UserIDResponse Successful Response
+     * @throws ApiError
+     */
+    public static getUserId(
+        username: string,
+    ): CancelablePromise<UserIDResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/user/id/{username}',
+            path: {
+                'username': username,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Get User
+     * @param userId
+     * @returns UserResponse Successful Response
+     * @throws ApiError
+     */
+    public static getUser(
+        userId: number,
+    ): CancelablePromise<UserResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/user/{id}',
+            query: {
+                'user_id': userId,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Edit User
+     * @param userId
+     * @param requestBody
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static editUser(
+        userId: number,
+        requestBody: UserBody,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/user/{id}',
+            query: {
+                'user_id': userId,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Delete User
+     * @param userId
+     * @returns any Successful Response
+     * @throws ApiError
+     */
+    public static deleteUser(
+        userId: number,
+    ): CancelablePromise<any> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/user/{id}',
+            query: {
+                'user_id': userId,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
         });
     }
     /**

--- a/frontend/src/lib/stores/user.ts
+++ b/frontend/src/lib/stores/user.ts
@@ -1,7 +1,7 @@
-﻿import {writable} from 'svelte/store';
+﻿import { writable } from "svelte/store";
 
 export const user = writable({
-    loggedIn: false,
-    username: "",
-    admin: true
-})
+	loggedIn: false,
+	id: 0,
+	admin: true,
+});

--- a/frontend/src/routes/Login.svelte
+++ b/frontend/src/routes/Login.svelte
@@ -14,7 +14,7 @@
 		clearToken();
 		Cookies.remove("auth");
 		$user.loggedIn = false;
-		$user.username = "";
+		$user.id = "";
 		$user.admin = false;
 	});
 
@@ -48,10 +48,14 @@
 			} else if (result["token"] != "") {
 				// User entered the correct username and password.
 				console.log("Response received. Token: " + result["token"]);
-				Cookies.set("auth", result["token"]);
+				
+				let isAdmin = (await Backend.getUser(result["userId"])).admin
 				$user.loggedIn = true;
-				$user.username = email;
-				$user.admin = true;
+				$user.id = result["userId"];
+				$user.admin = isAdmin;
+				Cookies.set("auth", result["token"]);
+				Cookies.set("id", result["userId"])
+				Cookies.set("admin", isAdmin.toString())
 				navigate(`/proteins`);
 			} else {
 				// User got a result, but both the error and token field are empty. This indicates a bug on our end.

--- a/frontend/src/routes/Signup.svelte
+++ b/frontend/src/routes/Signup.svelte
@@ -59,8 +59,11 @@
                     console.log("Response received. Token: " + loginResult["token"]);
                     Cookies.set("auth", loginResult["token"]);
                     $user.loggedIn = true;
-                    $user.username = email;
-                    $user.admin = true;
+                    $user.id = loginResult["userId"];
+                    $user.admin = false;
+                    
+                    Cookies.set("id", loginResult["userId"])
+				    Cookies.set("admin", "false")
                     navigate(`/proteins`);
                 } else {
                     // User got a result, but both the error and token field are empty. This indicates a bug on our end.

--- a/frontend/src/routes/UserList.svelte
+++ b/frontend/src/routes/UserList.svelte
@@ -1,35 +1,33 @@
-<script lang="ts">
-	import { Backend, clearToken, type LoginResponse, type UserResponse} from "../lib/backend";
-	import { Button, Label, Input } from "flowbite-svelte";
-	import Cookies from "js-cookie";
-	import { onMount } from "svelte";
-	import { navigate } from "svelte-routing";
-	import { user } from "../lib/stores/user";
-	
-	let userList: UserResponse[] = [];
-	
-	onMount(async () => {
-		const response = await Backend.getUsers();
-		userList = response.users;
-	});
+<script>
+	import UserTable from "../lib/UserTable.svelte";
 
+
+	let unique = {};
+
+	function reloadTable() {
+ 		unique = {};
+	}
 </script>
-
 <svelte:head>
 	<title>User List</title>
 </svelte:head>
 
-<table>
-	<tr>
-		<th>Username</th>
-		<th>Email</th>
-		<th>Role</th>
-	</tr>
-	{#each userList as user}
-		<tr>
-			<td>{user.username}</td>
-			<td>{user.email}</td>
-			<td>{user.admin}</td>
-		</tr>
-	{/each}
-</table>
+<div class="userlist">
+	<table>
+	{#key unique}
+		<UserTable {reloadTable} />
+	{/key}
+	</table>
+</div>
+
+<style>
+	.userlist {
+		width: 100%;
+		align-items: center;
+	}
+
+	table {
+		width: 95%;
+		margin:30px auto;
+	}
+</style>

--- a/frontend/src/routes/UserList.svelte
+++ b/frontend/src/routes/UserList.svelte
@@ -1,12 +1,24 @@
-<script>
+<script lang="ts">
 	import UserTable from "../lib/UserTable.svelte";
-
+	import { navigate } from "svelte-routing";
+	import { onMount } from "svelte";
+	import { user } from "../lib/stores/user";
 
 	let unique = {};
 
 	function reloadTable() {
  		unique = {};
 	}
+
+	onMount(async () => {
+		console.log($user)
+		if (!$user.admin) {
+			alert(
+				"You are not an admin. You are being redirected to home. TODO: Make this better."
+			);
+			navigate("/");
+		}
+	});
 </script>
 <svelte:head>
 	<title>User List</title>
@@ -14,6 +26,7 @@
 
 <div class="userlist">
 	<table>
+	<!-- Allows only the table to be reloaded, rather than the whole site. #key checks if a unique item is changed, and every {} is unique so it is reloaded when the function is called. -->
 	{#key unique}
 		<UserTable {reloadTable} />
 	{/key}

--- a/frontend/src/routes/UserList.svelte
+++ b/frontend/src/routes/UserList.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { Backend, clearToken, type LoginResponse, type UserResponse} from "../lib/backend";
+	import { Button, Label, Input } from "flowbite-svelte";
+	import Cookies from "js-cookie";
+	import { onMount } from "svelte";
+	import { navigate } from "svelte-routing";
+	import { user } from "../lib/stores/user";
+	
+	let userList: UserResponse[] = [];
+	
+	onMount(async () => {
+		const response = await Backend.getUsers();
+		userList = response.users;
+	});
+
+</script>
+
+<svelte:head>
+	<title>User List</title>
+</svelte:head>
+
+<table>
+	<tr>
+		<th>Username</th>
+		<th>Email</th>
+		<th>Role</th>
+	</tr>
+	{#each userList as user}
+		<tr>
+			<td>{user.username}</td>
+			<td>{user.email}</td>
+			<td>{user.admin}</td>
+		</tr>
+	{/each}
+</table>


### PR DESCRIPTION
This PR adds a page only accessible by admins that allows them to edit information about a user, including changing who is an admin. 

In doing so, I had to make it so only admins could access certain pages. This was previously implemented, but relied on an incorrect assumption about how svelte stores worked, and in the end, did not work. To fix it, I added storage into cookies, and then into the user store, with user ID, admin status, and login status all being stored and easily accessible.
Information can be checked with

 `$user.admin`
 `$user.id`
 `$user.loggedIn`

